### PR TITLE
chore: disable @next/next/no-html-link-for-pages ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,7 @@ const eslintConfig = [
   {
     rules: {
       '@next/next/no-img-element': 'off',
+      '@next/next/no-html-link-for-pages': 'off',
     },
   },
 ];


### PR DESCRIPTION
- Allow usage of native <a> tags for internal navigation
- Turn off enforcement of Next.js Link component for internal routes