### PR TITLE
feat(api): add explicit TypeScript return types to all API routes

### DIFF
--- a/src/app/api/animals-cache/route.ts
+++ b/src/app/api/animals-cache/route.ts
@@ -1,4 +1,5 @@
 import { getFirestoreData } from '@/lib/firebase/getFirestoreData';
+import { Animal } from '@/types';
 import { NextRequest, NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';
@@ -34,7 +35,7 @@ export const revalidate = 60; // Cache response for 60 seconds
  * Response is cached for 60 seconds using Next.js revalidate export.
  * Requires INTERNAL_API_SECRET environment variable for authentication.
  */
-export async function GET(req: NextRequest) {
+export async function GET(req: NextRequest): Promise<NextResponse<Animal[] | { error: string }>> {
   try {
     const token = req.headers.get('x-internal-token');
 

--- a/src/app/api/animals/route.ts
+++ b/src/app/api/animals/route.ts
@@ -179,7 +179,23 @@ async function getAnimalsFromCache(): Promise<Animal[]> {
  * - Returns paginated results with metadata when page/limit provided.
  * - For backward compatibility, if no pagination params provided, returns all results.
  */
-export async function POST(req: NextRequest) {
+export async function POST(
+  req: NextRequest
+): Promise<
+  | NextResponse<Animal[]>
+  | NextResponse<{
+      data: Animal[];
+      pagination: {
+        page: number;
+        limit: number;
+        total: number;
+        totalPages: number;
+        hasNextPage: boolean;
+        hasPrevPage: boolean;
+      };
+    }>
+  | NextResponse<{ error: string }>
+> {
   try {
     const { sortBy, sortOrder = 'asc', page, limit, ...filters } = await req.json();
 

--- a/src/app/api/authorized-emails/route.ts
+++ b/src/app/api/authorized-emails/route.ts
@@ -54,7 +54,9 @@ const CACHE_DURATION = 300000; // 5 minutes in milliseconds
  * Returns user emails as document IDs with additional user data.
  * Requires INTERNAL_API_SECRET environment variable for authentication.
  */
-export async function GET(req: NextRequest) {
+export async function GET(
+  req: NextRequest
+): Promise<NextResponse<AuthorizedUser[] | { error: string }>> {
   const token = req.headers.get('x-internal-token');
 
   if (token !== process.env.INTERNAL_API_SECRET) {

--- a/src/app/api/banners-cache/route.ts
+++ b/src/app/api/banners-cache/route.ts
@@ -1,42 +1,45 @@
 import { getFirestoreData } from '@/lib/firebase/getFirestoreData';
+import { BannerType } from '@/types';
 import { NextRequest, NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 600; // Cache response for 600 seconds
 
 /**
- * GET /api/contacts-cache - Retrieve all contacts data from Firestore with caching
+ * GET /api/banners-cache - Retrieve all banners data from Firestore with caching
  *
- * Internal API endpoint that fetches all WhatsApp contact information from Firestore
- * database. This endpoint is protected with an internal token and cached for 60 seconds
- * to improve performance. Used by other APIs to get fresh contact data for WhatsApp
- * integration throughout the application.
+ * Internal API endpoint that fetches all banner information from Firestore
+ * database. This endpoint is protected with an internal token and cached for 600 seconds
+ * to improve performance. Used by other APIs to get fresh banner data for display
+ * throughout the application.
  *
  * @param {NextRequest} req - Request object containing headers
  *
  * @headers {string} x-internal-token - Required internal API secret token for authentication
  *
- * @returns {NextResponse<WpContactType[]>} JSON response with all contacts from Firestore
+ * @returns {NextResponse<BannerType[]>} JSON response with all banners from Firestore
  * @returns {NextResponse<{error: string}>} 403 error if token is invalid or missing
  * @returns {NextResponse<{error: string}>} 500 error if Firestore operation fails
  *
  * @example
  * ```typescript
  * // Internal usage (from another API route)
- * const response = await fetch('/api/contacts-cache', {
+ * const response = await fetch('/api/banners-cache', {
  *   headers: {
  *     'x-internal-token': process.env.INTERNAL_API_SECRET!
  *   }
  * });
- * const contacts = await response.json();
+ * const banners = await response.json();
  * ```
  *
  * @note This is an internal API endpoint, not meant for direct client consumption.
  * Response is cached for 600 seconds using Next.js revalidate export.
  * Requires INTERNAL_API_SECRET environment variable for authentication.
- * Used by /api/contacts for public contact data access.
+ * Used by /api/banners for public banner data access.
  */
-export async function GET(req: NextRequest) {
+export async function GET(
+  req: NextRequest
+): Promise<NextResponse<BannerType[] | { error: string }>> {
   try {
     const token = req.headers.get('x-internal-token');
 
@@ -46,7 +49,7 @@ export async function GET(req: NextRequest) {
     const data = await getFirestoreData({ currentCollection: 'banners' }); // Fetch from Firestore
     return NextResponse.json(data);
   } catch (err) {
-    console.error('Error fetching contacts from Firestore:', err);
+    console.error('Error fetching banners from Firestore:', err);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/src/app/api/banners/route.ts
+++ b/src/app/api/banners/route.ts
@@ -2,10 +2,10 @@ import { NextResponse } from 'next/server';
 import { BannerType } from '@/types';
 
 /**
- * Fetches contacts data from the internal cache API with Next.js native caching.
+ * Fetches banners data from the internal cache API with Next.js native caching.
  * This function uses Next.js fetch with revalidation for reliable caching in Vercel.
  *
- * @returns {Promise<WpContactType[]>} Promise that resolves to array of WhatsApp contacts
+ * @returns {Promise<BannerType[]>} Promise that resolves to array of banners
  * @throws {Error} If the cache API request fails
  */
 async function getBannersFromCache(): Promise<BannerType[]> {
@@ -22,44 +22,43 @@ async function getBannersFromCache(): Promise<BannerType[]> {
   });
 
   if (!res.ok) {
-    throw new Error(`Failed to fetch contacts cache: ${res.status}`);
+    throw new Error(`Failed to fetch banners cache: ${res.status}`);
   }
 
   return res.json();
 }
 
 /**
- * GET /api/contacts - Retrieve WhatsApp contacts with Next.js native caching
+ * GET /api/banners - Retrieve banners with Next.js native caching
  *
- * Public API endpoint that retrieves all WhatsApp contact information for the
+ * Public API endpoint that retrieves all banner information for the
  * organization. Uses Next.js fetch with revalidation for reliable caching in
- * Vercel serverless environment. Used by contact components and WhatsApp
- * integration throughout the application.
+ * Vercel serverless environment. Used by banner components throughout the application.
  *
- * @returns {NextResponse<WpContactType[]>} JSON response with contacts array
+ * @returns {NextResponse<BannerType[]>} JSON response with banners array
  * @returns {NextResponse<{error: string}>} Error response with 500 status on failure
  *
  * @example
  * ```typescript
- * // Fetch contacts for WhatsApp integration
- * const response = await fetch('/api/contacts');
- * const contacts = await response.json();
+ * // Fetch banners for display
+ * const response = await fetch('/api/banners');
+ * const banners = await response.json();
  *
- * // Use in WhatsApp component
- * contacts.forEach(contact => {
- *   console.log(`${contact.name}: +${contact.countryCode}${contact.phone}`);
+ * // Use in banner component
+ * banners.forEach(banner => {
+ *   console.log(`${banner.title}: ${banner.description}`);
  * });
  * ```
  *
  * @example
  * ```typescript
  * // React component usage
- * const [contacts, setContacts] = useState<WpContactType[]>([]);
+ * const [banners, setBanners] = useState<BannerType[]>([]);
  *
  * useEffect(() => {
- *   fetch('/api/contacts')
+ *   fetch('/api/banners')
  *     .then(res => res.json())
- *     .then(setContacts);
+ *     .then(setBanners);
  * }, []);
  * ```
  *
@@ -68,7 +67,7 @@ async function getBannersFromCache(): Promise<BannerType[]> {
  * does not require authentication.
  */
 
-export async function GET() {
+export async function GET(): Promise<NextResponse<BannerType[] | { error: string }>> {
   try {
     // Get banners from cache using Next.js native caching
     const data = await getBannersFromCache();

--- a/src/app/api/check-user/route.ts
+++ b/src/app/api/check-user/route.ts
@@ -11,6 +11,14 @@ interface AuthorizedUserData {
 }
 
 /**
+ * Response types for check-user endpoint
+ */
+type CheckUserResponse =
+  | { authorized: false }
+  | { authorized: true; id: string; role: UserRole; name: string }
+  | { error: string };
+
+/**
  * POST /api/check-user - Verify if user email is authorized and get user details
  *
  * Public API endpoint that checks if a given email address is in the authorized
@@ -62,7 +70,7 @@ interface AuthorizedUserData {
  * Returns role "user" as default if no specific role is assigned.
  * This endpoint does not require authentication as it only returns authorization status.
  */
-export async function POST(request: NextRequest) {
+export async function POST(request: NextRequest): Promise<NextResponse<CheckUserResponse>> {
   const baseUrl =
     process.env.NODE_ENV === 'development'
       ? 'http://localhost:3000'

--- a/src/app/api/contacts-cache/route.ts
+++ b/src/app/api/contacts-cache/route.ts
@@ -1,4 +1,5 @@
 import { getFirestoreData } from '@/lib/firebase/getFirestoreData';
+import { WpContactType } from '@/types';
 import { NextRequest, NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';
@@ -36,7 +37,9 @@ export const revalidate = 60; // Cache response for 60 seconds
  * Requires INTERNAL_API_SECRET environment variable for authentication.
  * Used by /api/contacts for public contact data access.
  */
-export async function GET(req: NextRequest) {
+export async function GET(
+  req: NextRequest
+): Promise<NextResponse<WpContactType[] | { error: string }>> {
   try {
     const token = req.headers.get('x-internal-token');
 

--- a/src/app/api/contacts/route.ts
+++ b/src/app/api/contacts/route.ts
@@ -68,7 +68,7 @@ async function getContactsFromCache(): Promise<WpContactType[]> {
  * does not require authentication.
  */
 
-export async function GET() {
+export async function GET(): Promise<NextResponse<WpContactType[] | { error: string }>> {
   try {
     // Get contacts from cache using Next.js native caching
     const contacts = await getContactsFromCache();

--- a/src/app/api/delete-image/route.ts
+++ b/src/app/api/delete-image/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import cloudinary from '@/cloudinary';
 
 /**
+ * Response types for delete-image endpoint
+ */
+type DeleteImageResponse = { success: true; result: unknown } | { error: string };
+
+/**
  * DELETE /api/delete-image - Delete image from Cloudinary storage
  *
  * Internal API endpoint that deletes images from Cloudinary using the public ID.
@@ -14,7 +19,7 @@ import cloudinary from '@/cloudinary';
  *
  * @query {string} publicId - Cloudinary public ID of the image to delete
  *
- * @returns {NextResponse<{success: true, result: any}>} Success response with Cloudinary result
+ * @returns {NextResponse<{success: true, result: unknown}>} Success response with Cloudinary result
  * @returns {NextResponse<{error: string}>} 401 error if token is invalid or missing
  * @returns {NextResponse<{error: string}>} 400 error if publicId is missing
  * @returns {NextResponse<{error: string}>} 500 error if deletion fails or internal error
@@ -55,7 +60,7 @@ import cloudinary from '@/cloudinary';
  * Used for cleaning up images when animals are deleted or images are replaced.
  * Cloudinary public IDs must be exact matches for successful deletion.
  */
-export async function DELETE(req: NextRequest) {
+export async function DELETE(req: NextRequest): Promise<NextResponse<DeleteImageResponse>> {
   try {
     const { searchParams } = new URL(req.url);
     const publicId = searchParams.get('publicId');

--- a/src/app/api/generate-animal-id/route.ts
+++ b/src/app/api/generate-animal-id/route.ts
@@ -25,6 +25,11 @@ function normalizeName(name: string): string {
 }
 
 /**
+ * Response types for generate-animal-id endpoint
+ */
+type GenerateAnimalIdResponse = { id: string } | { error: string };
+
+/**
  * POST /api/generate-animal-id - Generate unique animal ID from name
  *
  * Internal API endpoint that generates a unique document ID for new animals
@@ -85,7 +90,7 @@ function normalizeName(name: string): string {
  * Uses incremental suffixes (name-1, name-2, etc.) for duplicate names.
  */
 
-export async function POST(req: NextRequest) {
+export async function POST(req: NextRequest): Promise<NextResponse<GenerateAnimalIdResponse>> {
   const token = req.headers.get('x-internal-token');
   if (token !== process.env.INTERNAL_API_SECRET) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });


### PR DESCRIPTION
- Add Promise<NextResponse<T>> return types to 9 API route handlers
- Define union types for success/error responses in all routes
- Fix banners API documentation (was referencing "contacts")
- Replace 'any' with 'unknown' in delete-image Cloudinary response
- Add type definitions for CheckUserResponse and GenerateAnimalIdResponse

Files modified:
- animals-cache/route.ts: Animal[] | { error: string }
- animals/route.ts: Complex pagination union type
- authorized-emails/route.ts: AuthorizedUser[] | { error: string }
- banners/route.ts: BannerType[] | { error: string }
- banners-cache/route.ts: BannerType[] | { error: string }
- check-user/route.ts: CheckUserResponse union type
- contacts/route.ts: WpContactType[] | { error: string }
- contacts-cache/route.ts: WpContactType[] | { error: string }
- delete-image/route.ts: DeleteImageResponse union type
- generate-animal-id/route.ts: GenerateAnimalIdResponse union type

This ensures type safety across the entire API layer and prevents TypeScript compilation errors when routes return error responses.