### PR TITLE
fix(ui): prevent browser-forced dark color inversion

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,13 @@
   --foreground: #171717;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #ffffff;
+    --foreground: #171717;
+  }
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="es">
+    <html lang="es" style={{ colorScheme: 'light dark' }}>
       <body className={` antialiased  ${roboto.variable}`}>
         <AuthProvider>
           <UnauthorizedAlert />


### PR DESCRIPTION
Declare explicit prefers-color-scheme: dark color values and add color-scheme meta hint to prevent browsers like Samsung Internet from applying aggressive color inversion on the site.